### PR TITLE
변수명 변경 및 Member 객체 join시 책임 분배

### DIFF
--- a/src/main/java/hello/kssoftware/login/LoginController.java
+++ b/src/main/java/hello/kssoftware/login/LoginController.java
@@ -1,6 +1,5 @@
 package hello.kssoftware.login;
 
-import hello.kssoftware.login.argumentresolver.Login;
 import hello.kssoftware.login.dto.MemberCreateDto;
 import hello.kssoftware.login.dto.MemberLoginDto;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,6 +11,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.Optional;
 
 @Slf4j
@@ -20,7 +20,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LoginController {
     private final MemberService memberService;
-    private final MemberRepository jpaMemberRepository;
+    private final MemberRepository memberRepository;
 
     @GetMapping("/signIn")
     public String signInForm(Model model) {
@@ -37,7 +37,7 @@ public class LoginController {
             return "login/signIn";
         }
 
-        Optional<Member> memberOptional = jpaMemberRepository.findUserId(memberLoginDto.getId());
+        Optional<Member> memberOptional = memberRepository.findUserId(memberLoginDto.getId());
         Member loginUser = memberOptional.get();
 
         HttpSession session = request.getSession();
@@ -60,7 +60,12 @@ public class LoginController {
             return "login/signUp";
         }
 
-        memberService.join(Member.createMember(memberCreateDto));
+        Member member = Member.createMember(memberCreateDto.getId(),
+                memberCreateDto.getName(),
+                memberCreateDto.getPassword(),
+                memberCreateDto.getNumber());
+        memberService.join(member);
+
         return "index";
     }
 

--- a/src/main/java/hello/kssoftware/login/Member.java
+++ b/src/main/java/hello/kssoftware/login/Member.java
@@ -1,6 +1,5 @@
 package hello.kssoftware.login;
 
-import hello.kssoftware.login.dto.MemberCreateDto;
 import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -28,13 +27,16 @@ public class Member {
     @Column(nullable = false)
     private Integer number;
 
-    public static Member createMember(MemberCreateDto memberCreateDto) {
+    protected Member() {}
+
+    public static Member createMember(String id, String name, String password, Integer number) {
         Member member = new Member();
-        member.id = memberCreateDto.getId();
-        member.name = memberCreateDto.getName();
-        member.password = memberCreateDto.getPassword();
-        member.number = memberCreateDto.getNumber();
+        member.id = id;
+        member.name = name;
+        member.password = password;
+        member.number = number;
         return member;
     }
+
 }
 

--- a/src/main/java/hello/kssoftware/login/MemberService.java
+++ b/src/main/java/hello/kssoftware/login/MemberService.java
@@ -11,18 +11,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository jpaMemberRepository;
+    private final MemberRepository memberRepository;
 
     public void join(Member member) {
-        jpaMemberRepository.save(member);
+        memberRepository.save(member);
     }
 
     public boolean isUserIdExists(String userId) {
-        return jpaMemberRepository.findUserId(userId).isPresent();
+        return memberRepository.findUserId(userId).isPresent();
     }
 
     public boolean isUserNameExists(String userName) {
-        List<Member> members = jpaMemberRepository.findByUserName(userName);
+        List<Member> members = memberRepository.findByUserName(userName);
         for (Member member : members) {
             if (member.getName().equals(userName)) {
                 return true;
@@ -33,6 +33,6 @@ public class MemberService {
 
 
     public List<Member> findMembers() {
-        return jpaMemberRepository.findAll();
+        return memberRepository.findAll();
     }
 }


### PR DESCRIPTION
jpaMemberRepository -> memberRepository 이름 변경
컨트롤러에서 memberCreateDto를 넘기는게 아닌 id, name, password, number등의 파라미터로 넘겨서 Member객체에서 조인

## 📄 Summary
> 변수명 변경
> Member join시 dto를 넘기는게 아닌 파라미터로 객체 필드값 넘기기

## 🙋🏻 More
>
